### PR TITLE
rust1.89: use objc-foundation-2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ async-broadcast = "0.5.1"
 libc = { version = "0.2", optional = true }
 objc = { version = "0.2.8", package = "objc-rs" }
 objc_id = "0.1.1"
-objc-foundation = "0.1.1"
+objc-foundation = { version = "0.2.0", package = "objc-foundation-2" }
 tokio = { version = "1.20.1", features = ["net", "io-util"], optional = true }
 
 [patch.crates-io]


### PR DESCRIPTION
Rust 1.89 seems to be changing how workspace vendored packages work and this seems to fix it